### PR TITLE
Add audience prop to WebAuth initialization

### DIFF
--- a/src/WebClient.js
+++ b/src/WebClient.js
@@ -18,7 +18,7 @@ export default class Auth0Client {
     };
 
     const {
-      domain, clientID, redirectUri, responseType, scope,
+      domain, clientID, redirectUri, responseType, scope, audience,
     } = this.props;
 
     this.client = new auth0.WebAuth({
@@ -27,6 +27,7 @@ export default class Auth0Client {
       redirectUri: resolveUri(redirectUri),
       responseType,
       scope,
+      audience,
     });
   }
 


### PR DESCRIPTION
`audience` property is used if trying to authenticate with an API.

See [here](https://community.auth0.com/t/access-token-too-short-jwt-malformed/9169/9)